### PR TITLE
Set product ol with flex-grow to push button towards bottom of product

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -186,6 +186,9 @@ main {
     margin: 10px 0;
     padding: 0 10px;
     width: 80%;
+
+    /* flex-grow 1 ensures the ol container pushes the button towards the bottom */
+    flex-grow: 1; 
 }
 
 .product > button {


### PR DESCRIPTION
Previously the buttons were positioned directly below where the product's description ended, which caused them to not be aligned with adjacent buttons. Setting flex-grow: 1 pushed the buttons to the bottom, now aligned.

BEFORE
<img width="975" alt="Screenshot 2023-08-03 at 11 53 39 PM" src="https://github.com/AlisonLSL-97/tutorial-landing-page/assets/59720232/c06f8aa1-16d1-4fce-b9ed-523794881ef8">

AFTER
<img width="1000" alt="Screenshot 2023-08-03 at 11 56 47 PM" src="https://github.com/AlisonLSL-97/tutorial-landing-page/assets/59720232/a421a982-7983-4d05-8804-7dd330cf97e1">